### PR TITLE
Mirror of hibernate hibernate-orm#2892

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
@@ -159,7 +159,6 @@ import org.hibernate.type.TypeResolver;
  */
 public class ModelBinder {
 	private static final CoreMessageLogger log = CoreLogging.messageLogger( ModelBinder.class );
-	private static final boolean debugEnabled = log.isDebugEnabled();
 
 	private final MetadataBuildingContext metadataBuildingContext;
 
@@ -3139,7 +3138,7 @@ public class ModelBinder {
 
 			collectionBinding.createAllKeys();
 
-			if ( debugEnabled ) {
+			if ( log.isDebugEnabled() ) {
 				log.debugf( "Mapped collection : " + getPluralAttributeSource().getAttributeRole().getFullPath() );
 				log.debugf( "   + table -> " + getCollectionBinding().getTable().getName() );
 				log.debugf( "   + key -> " + columns( getCollectionBinding().getKey() ) );
@@ -3264,7 +3263,7 @@ public class ModelBinder {
 			}
 
 
-			if ( debugEnabled ) {
+			if ( log.isDebugEnabled() ) {
 				log.debugf( "Mapping collection: %s -> %s", collectionBinding.getRole(), collectionBinding.getCollectionTable().getName() );
 			}
 
@@ -3603,7 +3602,7 @@ public class ModelBinder {
 						);
 					}
 
-					if ( debugEnabled ) {
+					if ( log.isDebugEnabled() ) {
 						log.debugf(
 								"Applying many-to-many filter [%s] as [%s] to collection [%s]",
 								filterSource.getName(),

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/QueryResultsCacheImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/QueryResultsCacheImpl.java
@@ -35,9 +35,6 @@ import org.hibernate.type.TypeHelper;
 public class QueryResultsCacheImpl implements QueryResultsCache {
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( QueryResultsCacheImpl.class );
 
-	private static final boolean DEBUGGING = LOG.isDebugEnabled();
-	private static final boolean TRACING = LOG.isTraceEnabled();
-
 	private final QueryResultsRegion cacheRegion;
 	private final TimestampsCache timestampsCache;
 
@@ -60,7 +57,7 @@ public class QueryResultsCacheImpl implements QueryResultsCache {
 			final List results,
 			final Type[] returnTypes,
 			final SharedSessionContractImplementor session) throws HibernateException {
-		if ( DEBUGGING ) {
+		if ( LOG.isDebugEnabled() ) {
 			LOG.debugf( "Caching query results in region: %s; timestamp=%s", cacheRegion.getName(), session.getTransactionStartTimestamp() );
 		}
 
@@ -76,12 +73,12 @@ public class QueryResultsCacheImpl implements QueryResultsCache {
 				resultRowForCache = TypeHelper.disassemble( (Object[]) aResult, returnTypes, null, session, null );
 			}
 			resultsCopy.add( resultRowForCache );
-			if ( TRACING ) {
+			if ( LOG.isTraceEnabled() ) {
 				logCachedResultRowDetails( returnTypes, aResult );
 			}
 		}
 
-		if ( TRACING ) {
+		if ( LOG.isTraceEnabled() ) {
 			logCachedResultDetails( key, null, returnTypes, resultsCopy );
 		}
 
@@ -102,7 +99,7 @@ public class QueryResultsCacheImpl implements QueryResultsCache {
 	}
 
 	private static void logCachedResultDetails(QueryKey key, Set querySpaces, Type[] returnTypes, List result) {
-		if ( !TRACING ) {
+		if ( !LOG.isTraceEnabled() ) {
 			return;
 		}
 		LOG.trace( "key.hashCode=" + key.hashCode() );
@@ -148,26 +145,26 @@ public class QueryResultsCacheImpl implements QueryResultsCache {
 			final String[] spaces,
 			final Type[] returnTypes,
 			final SharedSessionContractImplementor session) {
-		if ( DEBUGGING ) {
+		if ( LOG.isDebugEnabled() ) {
 			LOG.debugf( "Checking cached query results in region: %s", cacheRegion.getName() );
 		}
 
 		final CacheItem cacheItem = getCachedData( key, session );
 		if ( cacheItem == null ) {
-			if ( DEBUGGING ) {
+			if ( LOG.isDebugEnabled() ) {
 				LOG.debug( "Query results were not found in cache" );
 			}
 			return null;
 		}
 
 		if ( !timestampsCache.isUpToDate( spaces, cacheItem.timestamp, session ) ) {
-			if ( DEBUGGING ) {
+			if ( LOG.isDebugEnabled() ) {
 				LOG.debug( "Cached query results were not up-to-date" );
 			}
 			return null;
 		}
 
-		if ( DEBUGGING ) {
+		if ( LOG.isDebugEnabled() ) {
 			LOG.debug( "Returning cached query results" );
 		}
 
@@ -215,7 +212,7 @@ public class QueryResultsCacheImpl implements QueryResultsCache {
 				result.add(
 						TypeHelper.assemble( (Serializable[]) cached.get( i ), returnTypes, session, null )
 				);
-				if ( TRACING ) {
+				if ( LOG.isTraceEnabled() ) {
 					logCachedResultRowDetails( returnTypes, result.get( i ) );
 				}
 			}
@@ -231,7 +228,7 @@ public class QueryResultsCacheImpl implements QueryResultsCache {
 	}
 
 	private static void logCachedResultRowDetails(Type[] returnTypes, Object[] tuple) {
-		if ( !TRACING ) {
+		if ( !LOG.isTraceEnabled() ) {
 			return;
 		}
 		if ( tuple == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/TimestampsCacheEnabledImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/TimestampsCacheEnabledImpl.java
@@ -23,7 +23,6 @@ import org.jboss.logging.Logger;
  */
 public class TimestampsCacheEnabledImpl implements TimestampsCache {
 	private static final Logger log = Logger.getLogger( TimestampsCacheEnabledImpl.class );
-	private static final boolean DEBUG_ENABLED = log.isDebugEnabled();
 
 	private final TimestampsRegion timestampsRegion;
 
@@ -48,7 +47,7 @@ public class TimestampsCacheEnabledImpl implements TimestampsCache {
 		final Long ts = regionFactory.nextTimestamp() + regionFactory.getTimeout();
 
 		for ( Serializable space : spaces ) {
-			if ( DEBUG_ENABLED ) {
+			if ( log.isDebugEnabled() ) {
 				log.debugf( "Pre-invalidating space [%s], timestamp: %s", space, ts );
 			}
 
@@ -78,7 +77,7 @@ public class TimestampsCacheEnabledImpl implements TimestampsCache {
 		final Long ts = session.getFactory().getCache().getRegionFactory().nextTimestamp();
 
 		for (Serializable space : spaces) {
-			if ( DEBUG_ENABLED ) {
+			if ( log.isDebugEnabled() ) {
 				log.debugf( "Invalidating space [%s], timestamp: %s", space, ts );
 			}
 
@@ -113,7 +112,7 @@ public class TimestampsCacheEnabledImpl implements TimestampsCache {
 				}
 			}
 			else {
-				if ( DEBUG_ENABLED ) {
+				if ( log.isDebugEnabled() ) {
 					log.debugf(
 							"[%s] last update timestamp: %s",
 							space,

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractReadWriteAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractReadWriteAccess.java
@@ -26,7 +26,6 @@ import org.jboss.logging.Logger;
  */
 public abstract class AbstractReadWriteAccess extends AbstractCachedDomainDataAccess {
 	private static final Logger log = Logger.getLogger( AbstractReadWriteAccess.class );
-	private static final boolean DEBUG_ENABLED = log.isDebugEnabled();
 
 	private final UUID uuid = UUID.randomUUID();
 	private final AtomicLong nextLockId = new AtomicLong();
@@ -259,7 +258,7 @@ public abstract class AbstractReadWriteAccess extends AbstractCachedDomainDataAc
 
 		@Override
 		public boolean isReadable(long txTimestamp) {
-			if ( DEBUG_ENABLED ) {
+			if ( log.isDebugEnabled() ) {
 				log.debugf(
 						"Checking readability of read-write cache item [timestamp=`%s`, version=`%s`] : txTimestamp=`%s`",
 						(Object) timestamp,
@@ -273,7 +272,7 @@ public abstract class AbstractReadWriteAccess extends AbstractCachedDomainDataAc
 
 		@Override
 		public boolean isWriteable(long txTimestamp, Object newVersion, Comparator versionComparator) {
-			if ( DEBUG_ENABLED ) {
+			if ( log.isDebugEnabled() ) {
 				log.debugf(
 						"Checking writeability of read-write cache item [timestamp=`%s`, version=`%s`] : txTimestamp=`%s`, newVersion=`%s`",
 						timestamp,
@@ -346,7 +345,7 @@ public abstract class AbstractReadWriteAccess extends AbstractCachedDomainDataAc
 
 		@Override
 		public boolean isWriteable(long txTimestamp, Object newVersion, Comparator versionComparator) {
-			if ( DEBUG_ENABLED ) {
+			if ( log.isDebugEnabled() ) {
 				log.debugf(
 						"Checking writeability of read-write cache lock [timeout=`%s`, lockId=`%s`, version=`%s`, sourceUuid=%s, multiplicity=`%s`, unlockTimestamp=`%s`] : txTimestamp=`%s`, newVersion=`%s`",
 						timeout,

--- a/hibernate-core/src/main/java/org/hibernate/cfg/CollectionSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/CollectionSecondPass.java
@@ -46,15 +46,14 @@ public abstract class CollectionSecondPass implements SecondPass {
 
 	public void doSecondPass(java.util.Map persistentClasses)
 			throws MappingException {
-		final boolean debugEnabled = LOG.isDebugEnabled();
-		if ( debugEnabled ) {
+		if ( LOG.isDebugEnabled() ) {
 			LOG.debugf( "Second pass for collection: %s", collection.getRole() );
 		}
 
 		secondPass( persistentClasses, localInheritedMetas ); // using local since the inheritedMetas at this point is not the correct map since it is always the empty map
 		collection.createAllKeys();
 
-		if ( debugEnabled ) {
+		if ( LOG.isDebugEnabled() ) {
 			String msg = "Mapped collection key: " + columns( collection.getKey() );
 			if ( collection.isIndexed() )
 				msg += ", index: " + columns( ( (IndexedCollection) collection ).getIndex() );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/Settings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Settings.java
@@ -64,9 +64,7 @@ public final class Settings {
 		this.defaultCatalogName = defaultCatalogName;
 		this.defaultSchemaName = defaultSchemaName;
 
-		final boolean debugEnabled =  LOG.isDebugEnabled();
-
-		if ( debugEnabled ) {
+		if ( LOG.isDebugEnabled() ) {
 			LOG.debugf( "SessionFactory name : %s", sessionFactoryOptions.getSessionFactoryName() );
 			LOG.debugf( "Automatic flush during beforeCompletion(): %s", enabledDisabled( sessionFactoryOptions.isFlushBeforeCompletionEnabled() ) );
 			LOG.debugf( "Automatic session close at end of transaction: %s", enabledDisabled( sessionFactoryOptions.isAutoCloseSessionEnabled() ) );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
@@ -893,8 +893,7 @@ public abstract class CollectionBinder {
 			MetadataBuildingContext buildingContext,
 			Map<XClass, InheritanceState> inheritanceStatePerClass) {
 
-		final boolean debugEnabled = LOG.isDebugEnabled();
-		if ( debugEnabled ) {
+		if ( LOG.isDebugEnabled() ) {
 			LOG.debugf( "Binding a OneToMany: %s.%s through a foreign key", propertyHolder.getEntityName(), propertyName );
 		}
 		if ( buildingContext == null ) {
@@ -932,7 +931,7 @@ public abstract class CollectionBinder {
 			column.setJoins( joins );
 			collection.setCollectionTable( column.getTable() );
 		}
-		if ( debugEnabled ) {
+		if ( LOG.isDebugEnabled() ) {
 			LOG.debugf( "Mapping collection: %s -> %s", collection.getRole(), collection.getCollectionTable().getName() );
 		}
 		bindFilters( false );

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/ParameterBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/ParameterBinder.java
@@ -121,7 +121,6 @@ public class ParameterBinder {
 			final NamedParameterSource source,
 			final SessionImplementor session) throws SQLException, HibernateException {
 		if ( namedParams != null ) {
-			final boolean debugEnabled = LOG.isDebugEnabled();
 			// assumes that types are all of span 1
 			final Iterator iter = namedParams.entrySet().iterator();
 			int result = 0;
@@ -131,7 +130,7 @@ public class ParameterBinder {
 				final TypedValue typedVal = (TypedValue) e.getValue();
 				final int[] locations = source.getNamedParameterLocations( name );
 				for ( int location : locations ) {
-					if ( debugEnabled ) {
+					if ( LOG.isDebugEnabled() ) {
 						LOG.debugf(
 								"bindNamedParameters() %s -> %s [%s]",
 								typedVal.getValue(),

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -82,7 +82,6 @@ public class StatefulPersistenceContext implements PersistenceContext {
 			StatefulPersistenceContext.class.getName()
 	);
 
-	private static final boolean TRACE_ENABLED = LOG.isTraceEnabled();
 	private static final int INIT_COLL_SIZE = 8;
 
 	private SharedSessionContractImplementor session;
@@ -913,7 +912,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	@Override
 	public void initializeNonLazyCollections() throws HibernateException {
 		if ( loadCounter == 0 ) {
-			if ( TRACE_ENABLED ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.trace( "Initializing non-lazy collections" );
 			}
 
@@ -1436,8 +1435,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	 * @throws IOException serialization errors.
 	 */
 	public void serialize(ObjectOutputStream oos) throws IOException {
-		final boolean tracing = LOG.isTraceEnabled();
-		if ( tracing ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.trace( "Serializing persistence-context" );
 		}
 
@@ -1445,7 +1443,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		oos.writeBoolean( hasNonReadOnlyEntities );
 
 		oos.writeInt( entitiesByKey.size() );
-		if ( tracing ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.trace( "Starting serialization of [" + entitiesByKey.size() + "] entitiesByKey entries" );
 		}
 		for ( Map.Entry<EntityKey,Object> entry : entitiesByKey.entrySet() ) {
@@ -1454,7 +1452,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		}
 
 		oos.writeInt( entitiesByUniqueKey.size() );
-		if ( tracing ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.trace( "Starting serialization of [" + entitiesByUniqueKey.size() + "] entitiesByUniqueKey entries" );
 		}
 		for ( Map.Entry<EntityUniqueKey,Object> entry : entitiesByUniqueKey.entrySet() ) {
@@ -1463,7 +1461,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		}
 
 		oos.writeInt( proxiesByKey.size() );
-		if ( tracing ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.trace( "Starting serialization of [" + proxiesByKey.size() + "] proxiesByKey entries" );
 		}
 		for ( Map.Entry<EntityKey,Object> entry : proxiesByKey.entrySet() ) {
@@ -1472,7 +1470,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		}
 
 		oos.writeInt( entitySnapshotsByKey.size() );
-		if ( tracing ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.trace( "Starting serialization of [" + entitySnapshotsByKey.size() + "] entitySnapshotsByKey entries" );
 		}
 		for ( Map.Entry<EntityKey,Object> entry : entitySnapshotsByKey.entrySet() ) {
@@ -1483,7 +1481,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		entityEntryContext.serialize( oos );
 
 		oos.writeInt( collectionsByKey.size() );
-		if ( tracing ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.trace( "Starting serialization of [" + collectionsByKey.size() + "] collectionsByKey entries" );
 		}
 		for ( Map.Entry<CollectionKey,PersistentCollection> entry : collectionsByKey.entrySet() ) {
@@ -1492,7 +1490,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		}
 
 		oos.writeInt( collectionEntries.size() );
-		if ( tracing ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.trace( "Starting serialization of [" + collectionEntries.size() + "] collectionEntries entries" );
 		}
 		for ( Map.Entry<PersistentCollection,CollectionEntry> entry : collectionEntries.entrySet() ) {
@@ -1501,7 +1499,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		}
 
 		oos.writeInt( arrayHolders.size() );
-		if ( tracing ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.trace( "Starting serialization of [" + arrayHolders.size() + "] arrayHolders entries" );
 		}
 		for ( Map.Entry<Object,PersistentCollection> entry : arrayHolders.entrySet() ) {
@@ -1510,7 +1508,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		}
 
 		oos.writeInt( nullifiableEntityKeys.size() );
-		if ( tracing ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.trace( "Starting serialization of [" + nullifiableEntityKeys.size() + "] nullifiableEntityKey entries" );
 		}
 		for ( EntityKey entry : nullifiableEntityKeys ) {
@@ -1532,8 +1530,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	public static StatefulPersistenceContext deserialize(
 			ObjectInputStream ois,
 			SessionImplementor session) throws IOException, ClassNotFoundException {
-		final boolean tracing = LOG.isTraceEnabled();
-		if ( tracing ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.trace( "Deserializing persistence-context" );
 		}
 		final StatefulPersistenceContext rtn = new StatefulPersistenceContext( session );
@@ -1550,7 +1547,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 			rtn.hasNonReadOnlyEntities = ois.readBoolean();
 
 			int count = ois.readInt();
-			if ( tracing ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.trace( "Starting deserialization of [" + count + "] entitiesByKey entries" );
 			}
 			rtn.entitiesByKey = new HashMap<>( count < INIT_COLL_SIZE ? INIT_COLL_SIZE : count );
@@ -1559,7 +1556,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 			}
 
 			count = ois.readInt();
-			if ( tracing ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.trace( "Starting deserialization of [" + count + "] entitiesByUniqueKey entries" );
 			}
 			rtn.entitiesByUniqueKey = new HashMap<>( count < INIT_COLL_SIZE ? INIT_COLL_SIZE : count );
@@ -1568,7 +1565,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 			}
 
 			count = ois.readInt();
-			if ( tracing ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.trace( "Starting deserialization of [" + count + "] proxiesByKey entries" );
 			}
 			//noinspection unchecked
@@ -1589,14 +1586,14 @@ public class StatefulPersistenceContext implements PersistenceContext {
 				}
 				else {
 					// otherwise, the proxy was pruned during the serialization process
-					if ( tracing ) {
+					if ( LOG.isTraceEnabled() ) {
 						LOG.trace( "Encountered pruned proxy" );
 					}
 				}
 			}
 
 			count = ois.readInt();
-			if ( tracing ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.trace( "Starting deserialization of [" + count + "] entitySnapshotsByKey entries" );
 			}
 			rtn.entitySnapshotsByKey = new HashMap<>( count < INIT_COLL_SIZE ? INIT_COLL_SIZE : count );
@@ -1607,7 +1604,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 			rtn.entityEntryContext = EntityEntryContext.deserialize( ois, rtn );
 
 			count = ois.readInt();
-			if ( tracing ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.trace( "Starting deserialization of [" + count + "] collectionsByKey entries" );
 			}
 			rtn.collectionsByKey = new HashMap<>( count < INIT_COLL_SIZE ? INIT_COLL_SIZE : count );
@@ -1616,7 +1613,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 			}
 
 			count = ois.readInt();
-			if ( tracing ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.trace( "Starting deserialization of [" + count + "] collectionEntries entries" );
 			}
 			rtn.collectionEntries = IdentityMap.instantiateSequenced( count < INIT_COLL_SIZE ? INIT_COLL_SIZE : count );
@@ -1628,7 +1625,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 			}
 
 			count = ois.readInt();
-			if ( tracing ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.trace( "Starting deserialization of [" + count + "] arrayHolders entries" );
 			}
 			rtn.arrayHolders = new IdentityHashMap<>( count < INIT_COLL_SIZE ? INIT_COLL_SIZE : count );
@@ -1637,7 +1634,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 			}
 
 			count = ois.readInt();
-			if ( tracing ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.trace( "Starting deserialization of [" + count + "] nullifiableEntityKey entries" );
 			}
 			rtn.nullifiableEntityKeys = new HashSet<>();

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -140,8 +140,7 @@ public final class TwoPhaseLoad {
 		final Serializable id = entityEntry.getId();
 		final Object[] hydratedState = entityEntry.getLoadedState();
 
-		final boolean debugEnabled = LOG.isDebugEnabled();
-		if ( debugEnabled ) {
+		if ( LOG.isDebugEnabled() ) {
 			LOG.debugf(
 					"Resolving attributes for %s",
 					MessageHelper.infoString( persister, id, session.getFactory() )
@@ -209,7 +208,7 @@ public final class TwoPhaseLoad {
 		final SessionFactoryImplementor factory = session.getFactory();
 		if ( persister.canWriteToCache() && session.getCacheMode().isPutEnabled() ) {
 
-			if ( debugEnabled ) {
+			if ( LOG.isDebugEnabled() ) {
 				LOG.debugf(
 						"Adding entity to second-level cache: %s",
 						MessageHelper.infoString( persister, id, session.getFactory() )
@@ -301,7 +300,7 @@ public final class TwoPhaseLoad {
 			persistenceContext.setEntryStatus( entityEntry, Status.MANAGED );
 		}
 
-		if ( debugEnabled ) {
+		if ( LOG.isDebugEnabled() ) {
 			LOG.debugf(
 					"Done materializing entity %s",
 					MessageHelper.infoString( persister, id, session.getFactory() )

--- a/hibernate-core/src/main/java/org/hibernate/engine/loading/internal/CollectionLoadContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/loading/internal/CollectionLoadContext.java
@@ -206,16 +206,15 @@ public class CollectionLoadContext {
 	}
 
 	private void endLoadingCollections(CollectionPersister persister, List<LoadingCollectionEntry> matchedCollectionEntries) {
-		final boolean debugEnabled = LOG.isDebugEnabled();
 		if ( matchedCollectionEntries == null ) {
-			if ( debugEnabled ) {
+			if ( LOG.isDebugEnabled() ) {
 				LOG.debugf( "No collections were found in result set for role: %s", persister.getRole() );
 			}
 			return;
 		}
 
 		final int count = matchedCollectionEntries.size();
-		if ( debugEnabled ) {
+		if ( LOG.isDebugEnabled() ) {
 			LOG.debugf( "%s collections were found in result set for role: %s", count, persister.getRole() );
 		}
 
@@ -223,7 +222,7 @@ public class CollectionLoadContext {
 			endLoadingCollection( matchedCollectionEntry, persister );
 		}
 
-		if ( debugEnabled ) {
+		if ( LOG.isDebugEnabled() ) {
 			LOG.debugf( "%s collections initialized for role: %s", count, persister.getRole() );
 		}
 	}
@@ -316,14 +315,13 @@ public class CollectionLoadContext {
 		final SharedSessionContractImplementor session = getLoadContext().getPersistenceContext().getSession();
 		final SessionFactoryImplementor factory = session.getFactory();
 
-		final boolean debugEnabled = LOG.isDebugEnabled();
-		if ( debugEnabled ) {
+		if ( LOG.isDebugEnabled() ) {
 			LOG.debugf( "Caching collection: %s", MessageHelper.collectionInfoString( persister, lce.getCollection(), lce.getKey(), session ) );
 		}
 
 		if ( !session.getLoadQueryInfluencers().getEnabledFilters().isEmpty() && persister.isAffectedByEnabledFilters( session ) ) {
 			// some filters affecting the collection are enabled on the session, so do not do the put into the cache.
-			if ( debugEnabled ) {
+			if ( LOG.isDebugEnabled() ) {
 				LOG.debug( "Refusing to add to cache due to enabled filters" );
 			}
 			// todo : add the notion of enabled filters to the cache key to differentiate filtered collections from non-filtered;

--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/HQLQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/HQLQueryPlan.java
@@ -61,11 +61,6 @@ public class HQLQueryPlan implements Serializable {
 	private final boolean shallow;
 
 	/**
-	* We'll check the trace level only once per instance
-	*/
-	private final boolean traceEnabled = LOG.isTraceEnabled();
-
-	/**
 	 * Constructs a HQLQueryPlan
 	 *
 	 * @param hql The HQL query
@@ -197,7 +192,7 @@ public class HQLQueryPlan implements Serializable {
 	public List performList(
 			QueryParameters queryParameters,
 			SharedSessionContractImplementor session) throws HibernateException {
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.tracev( "Find: {0}", getSourceQuery() );
 			queryParameters.traceParameters( session.getFactory() );
 		}
@@ -306,7 +301,7 @@ public class HQLQueryPlan implements Serializable {
 	public Iterator performIterate(
 			QueryParameters queryParameters,
 			EventSource session) throws HibernateException {
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.tracev( "Iterate: {0}", getSourceQuery() );
 			queryParameters.traceParameters( session.getFactory() );
 		}
@@ -344,7 +339,7 @@ public class HQLQueryPlan implements Serializable {
 	public ScrollableResultsImplementor performScroll(
 			QueryParameters queryParameters,
 			SharedSessionContractImplementor session) throws HibernateException {
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.tracev( "Iterate: {0}", getSourceQuery() );
 			queryParameters.traceParameters( session.getFactory() );
 		}
@@ -370,7 +365,7 @@ public class HQLQueryPlan implements Serializable {
 	 */
 	public int performExecuteUpdate(QueryParameters queryParameters, SharedSessionContractImplementor session)
 			throws HibernateException {
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.tracev( "Execute update: {0}", getSourceQuery() );
 			queryParameters.traceParameters( session.getFactory() );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractSaveEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractSaveEventListener.java
@@ -488,19 +488,18 @@ public abstract class AbstractSaveEventListener
 			EntityEntry entry, //pass this as an argument only to avoid double looking
 			SessionImplementor source) {
 
-		final boolean traceEnabled = LOG.isTraceEnabled();
 		if ( entry != null ) { // the object is persistent
 
 			//the entity is associated with the session, so check its status
 			if ( entry.getStatus() != Status.DELETED ) {
 				// do nothing for persistent instances
-				if ( traceEnabled ) {
+				if ( LOG.isTraceEnabled() ) {
 					LOG.tracev( "Persistent instance of: {0}", getLoggableName( entityName, entity ) );
 				}
 				return EntityState.PERSISTENT;
 			}
 			// ie. e.status==DELETED
-			if ( traceEnabled ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.tracev( "Deleted instance of: {0}", getLoggableName( entityName, entity ) );
 			}
 			return EntityState.DELETED;
@@ -511,12 +510,12 @@ public abstract class AbstractSaveEventListener
 		// try interceptor and unsaved-value
 
 		if ( ForeignKeys.isTransient( entityName, entity, getAssumedUnsaved(), source ) ) {
-			if ( traceEnabled ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.tracev( "Transient instance of: {0}", getLoggableName( entityName, entity ) );
 			}
 			return EntityState.TRANSIENT;
 		}
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.tracev( "Detached instance of: {0}", getLoggableName( entityName, entity ) );
 		}
 		return EntityState.DETACHED;

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
@@ -42,8 +42,7 @@ public class DefaultInitializeCollectionEventListener implements InitializeColle
 			throw new HibernateException( "collection was evicted" );
 		}
 		if ( !collection.wasInitialized() ) {
-			final boolean traceEnabled = LOG.isTraceEnabled();
-			if ( traceEnabled ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.tracev(
 						"Initializing collection {0}",
 						MessageHelper.collectionInfoString(
@@ -64,16 +63,16 @@ public class DefaultInitializeCollectionEventListener implements InitializeColle
 			);
 
 			if ( foundInCache ) {
-				if ( traceEnabled ) {
+				if ( LOG.isTraceEnabled() ) {
 					LOG.trace( "Collection initialized from cache" );
 				}
 			}
 			else {
-				if ( traceEnabled ) {
+				if ( LOG.isTraceEnabled() ) {
 					LOG.trace( "Collection not cached" );
 				}
 				ce.getLoadedPersister().initialize( ce.getLoadedKey(), source );
-				if ( traceEnabled ) {
+				if ( LOG.isTraceEnabled() ) {
 					LOG.trace( "Collection initialized" );
 				}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
@@ -44,8 +44,6 @@ public class DefaultLoadEventListener implements LoadEventListener {
 
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( DefaultLoadEventListener.class );
 
-	private static final boolean traceEnabled = LOG.isTraceEnabled();
-
 	/**
 	 * Handle the given load event.
 	 *
@@ -234,7 +232,7 @@ public class DefaultLoadEventListener implements LoadEventListener {
 			final EntityKey keyToLoad,
 			final LoadEventListener.LoadType options) {
 
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.tracev(
 					"Loading entity: {0}",
 					MessageHelper.infoString( persister, event.getEntityId(), event.getSession().getFactory() )
@@ -282,7 +280,7 @@ public class DefaultLoadEventListener implements LoadEventListener {
 			final LoadEventListener.LoadType options,
 			final PersistenceContext persistenceContext,
 			final Object proxy) {
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.trace( "Entity proxy found in session cache" );
 		}
 		LazyInitializer li = ( (HibernateProxy) proxy ).getHibernateLazyInitializer();
@@ -324,7 +322,7 @@ public class DefaultLoadEventListener implements LoadEventListener {
 		Object existing = persistenceContext.getEntity( keyToLoad );
 		if ( existing != null ) {
 			// return existing object or initialized proxy (unless deleted)
-			if ( traceEnabled ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.trace( "Entity found in session cache" );
 			}
 			if ( options.isCheckDeleted() ) {
@@ -336,7 +334,7 @@ public class DefaultLoadEventListener implements LoadEventListener {
 			}
 			return existing;
 		}
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.trace( "Creating new proxy for entity" );
 		}
 		// return new uninitialized proxy
@@ -415,7 +413,7 @@ public class DefaultLoadEventListener implements LoadEventListener {
 			final EntityKey keyToLoad,
 			final LoadEventListener.LoadType options) {
 
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.tracev(
 					"Attempting to resolve: {0}",
 					MessageHelper.infoString( persister, event.getEntityId(), event.getSession().getFactory() )
@@ -435,7 +433,7 @@ public class DefaultLoadEventListener implements LoadEventListener {
 
 		entity = CacheEntityLoaderHelper.INSTANCE.loadFromSecondLevelCache( event, persister, keyToLoad );
 		if ( entity != null ) {
-			if ( traceEnabled ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.tracev(
 						"Resolved object in second-level cache: {0}",
 						MessageHelper.infoString( persister, event.getEntityId(), event.getSession().getFactory() )
@@ -443,7 +441,7 @@ public class DefaultLoadEventListener implements LoadEventListener {
 			}
 		}
 		else {
-			if ( traceEnabled ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.tracev(
 						"Object not resolved in any cache: {0}",
 						MessageHelper.infoString( persister, event.getEntityId(), event.getSession().getFactory() )

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultReplicateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultReplicateEventListener.java
@@ -82,9 +82,8 @@ public class DefaultReplicateEventListener extends AbstractSaveEventListener imp
 			oldVersion = persister.getCurrentVersion( id, source );
 		}
 
-		final boolean traceEnabled = LOG.isTraceEnabled();
 		if ( oldVersion != null ) {
-			if ( traceEnabled ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.tracev(
 						"Found existing row for {0}", MessageHelper.infoString(
 						persister,
@@ -109,7 +108,7 @@ public class DefaultReplicateEventListener extends AbstractSaveEventListener imp
 			if ( canReplicate ) {
 				performReplication( entity, id, realOldVersion, persister, replicationMode, source );
 			}
-			else if ( traceEnabled ) {
+			else if ( LOG.isTraceEnabled() ) {
 				LOG.trace( "No need to replicate" );
 			}
 
@@ -117,7 +116,7 @@ public class DefaultReplicateEventListener extends AbstractSaveEventListener imp
 		}
 		else {
 			// no existing row - do an insert
-			if ( traceEnabled ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.tracev(
 						"No existing row, replicating new instance {0}",
 						MessageHelper.infoString( persister, id, source.getFactory() )

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultResolveNaturalIdEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultResolveNaturalIdEventListener.java
@@ -54,8 +54,7 @@ public class DefaultResolveNaturalIdEventListener
 	protected Serializable resolveNaturalId(final ResolveNaturalIdEvent event) {
 		final EntityPersister persister = event.getEntityPersister();
 
-		final boolean traceEnabled = LOG.isTraceEnabled();
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.tracev(
 					"Attempting to resolve: {0}#{1}",
 					MessageHelper.infoString( persister ),
@@ -65,7 +64,7 @@ public class DefaultResolveNaturalIdEventListener
 
 		Serializable entityId = resolveFromCache( event );
 		if ( entityId != null ) {
-			if ( traceEnabled ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.tracev(
 						"Resolved object in cache: {0}#{1}",
 						MessageHelper.infoString( persister ),
@@ -75,7 +74,7 @@ public class DefaultResolveNaturalIdEventListener
 			return entityId;
 		}
 
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.tracev(
 					"Object not resolved in any cache: {0}#{1}",
 					MessageHelper.infoString( persister ),

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
@@ -99,8 +99,7 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 	}
 
 	protected Serializable entityIsPersistent(SaveOrUpdateEvent event) throws HibernateException {
-		final boolean traceEnabled = LOG.isTraceEnabled();
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.trace( "Ignoring persistent instance" );
 		}
 		EntityEntry entityEntry = event.getEntry();
@@ -137,7 +136,7 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 
 			}
 
-			if ( traceEnabled ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.tracev(
 						"Object already associated with session: {0}",
 						MessageHelper.infoString( entityEntry.getPersister(), savedId, factory )
@@ -266,12 +265,11 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 			Object entity,
 			EntityPersister persister) throws HibernateException {
 
-		final boolean traceEnabled = LOG.isTraceEnabled();
-		if ( traceEnabled && !persister.isMutable() ) {
+		if ( LOG.isTraceEnabled() && !persister.isMutable() ) {
 			LOG.trace( "Immutable instance passed to performUpdate()" );
 		}
 
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.tracev(
 					"Updating {0}",
 					MessageHelper.infoString( persister, event.getRequestedId(), event.getSession().getFactory() )
@@ -318,7 +316,7 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 
 		persister.afterReassociate( entity, source );
 
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.tracev(
 					"Updating {0}", MessageHelper.infoString(
 					persister,

--- a/hibernate-core/src/main/java/org/hibernate/id/IncrementGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/IncrementGenerator.java
@@ -103,8 +103,7 @@ public class IncrementGenerator implements IdentifierGenerator, Configurable {
 	private void initializePreviousValueHolder(SharedSessionContractImplementor session) {
 		previousValueHolder = IdentifierGeneratorHelper.getIntegralDataTypeHolder( returnClass );
 
-		final boolean debugEnabled = LOG.isDebugEnabled();
-		if ( debugEnabled ) {
+		if ( LOG.isDebugEnabled() ) {
 			LOG.debugf( "Fetching initial value: %s", sql );
 		}
 		try {
@@ -119,7 +118,7 @@ public class IncrementGenerator implements IdentifierGenerator, Configurable {
 						previousValueHolder.initialize( 1L );
 					}
 					sql = null;
-					if ( debugEnabled ) {
+					if ( LOG.isDebugEnabled() ) {
 						LOG.debugf( "First free id: %s", previousValueHolder.makeValue() );
 					}
 				}

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -213,7 +213,6 @@ public final class SessionImpl
 		extends AbstractSessionImpl
 		implements EventSource, SessionImplementor, HibernateEntityManagerImplementor {
 	private static final EntityManagerMessageLogger log = HEMLogging.messageLogger( SessionImpl.class );
-	private static final boolean TRACE_ENABLED = log.isTraceEnabled();
 
 
 	private static final String[] ENTITY_MANAGER_SPECIFIC_PROPERTIES = {
@@ -288,7 +287,7 @@ public final class SessionImpl
 		setDefaultProperties();
 		applyProperties();
 
-		if ( TRACE_ENABLED ) {
+		if ( log.isTraceEnabled() ) {
 			log.tracef( "Opened Session [%s] at timestamp: %s", getSessionIdentifier(), getTimestamp() );
 		}
 	}
@@ -423,7 +422,7 @@ public final class SessionImpl
 	}
 
 	public void closeWithoutOpenChecks() throws HibernateException {
-		if ( TRACE_ENABLED ) {
+		if ( log.isTraceEnabled() ) {
 			log.tracef( "Closing session [%s]", getSessionIdentifier() );
 		}
 
@@ -961,7 +960,7 @@ public final class SessionImpl
 	public void delete(String entityName, Object object, boolean isCascadeDeleteEnabled, Set transientEntities)
 			throws HibernateException {
 		checkOpenOrWaitingForAutoClose();
-		if ( TRACE_ENABLED && persistenceContext.isRemovingOrphanBeforeUpates() ) {
+		if ( log.isTraceEnabled() && persistenceContext.isRemovingOrphanBeforeUpates() ) {
 			logRemoveOrphanBeforeUpdates( "before continuing", entityName, object );
 		}
 		fireDelete(
@@ -974,7 +973,7 @@ public final class SessionImpl
 				),
 				transientEntities
 		);
-		if ( TRACE_ENABLED && persistenceContext.isRemovingOrphanBeforeUpates() ) {
+		if ( log.isTraceEnabled() && persistenceContext.isRemovingOrphanBeforeUpates() ) {
 			logRemoveOrphanBeforeUpdates( "after continuing", entityName, object );
 		}
 	}
@@ -983,7 +982,7 @@ public final class SessionImpl
 	public void removeOrphanBeforeUpdates(String entityName, Object child) {
 		// TODO: The removeOrphan concept is a temporary "hack" for HHH-6484.  This should be removed once action/task
 		// ordering is improved.
-		if ( TRACE_ENABLED ) {
+		if ( log.isTraceEnabled() ) {
 			logRemoveOrphanBeforeUpdates( "begin", entityName, child );
 		}
 		persistenceContext.beginRemoveOrphanBeforeUpdates();
@@ -993,7 +992,7 @@ public final class SessionImpl
 		}
 		finally {
 			persistenceContext.endRemoveOrphanBeforeUpdates();
-			if ( TRACE_ENABLED ) {
+			if ( log.isTraceEnabled() ) {
 				logRemoveOrphanBeforeUpdates( "end", entityName, child );
 			}
 		}
@@ -2356,7 +2355,7 @@ public final class SessionImpl
 		StringBuilder buf = new StringBuilder( 500 )
 				.append( "SessionImpl(" ).append( System.identityHashCode( this ) );
 		if ( !isClosed() ) {
-			if ( TRACE_ENABLED ) {
+			if ( log.isTraceEnabled() ) {
 				buf.append( persistenceContext )
 					.append( ";" )
 					.append( actionQueue );
@@ -3147,7 +3146,6 @@ public final class SessionImpl
 				return;
 			}
 
-			final boolean debugEnabled = log.isDebugEnabled();
 			for ( Serializable pk : getPersistenceContext().getNaturalIdHelper()
 					.getCachedPkResolutions( entityPersister ) ) {
 				final EntityKey entityKey = generateEntityKey( pk, entityPersister );
@@ -3155,7 +3153,7 @@ public final class SessionImpl
 				final EntityEntry entry = getPersistenceContext().getEntry( entity );
 
 				if ( entry == null ) {
-					if ( debugEnabled ) {
+					if ( log.isDebugEnabled() ) {
 						log.debug(
 								"Cached natural-id/pk resolution linked to null EntityEntry in persistence context : "
 										+ MessageHelper.infoString( entityPersister, pk, getFactory() )
@@ -3975,7 +3973,7 @@ public final class SessionImpl
 	 * @throws IOException Indicates a general IO stream exception
 	 */
 	private void writeObject(ObjectOutputStream oos) throws IOException {
-		if ( TRACE_ENABLED ) {
+		if ( log.isTraceEnabled() ) {
 			log.tracef( "Serializing Session [%s]", getSessionIdentifier() );
 		}
 
@@ -3996,7 +3994,7 @@ public final class SessionImpl
 	 * @throws ClassNotFoundException Indicates a class resolution issue
 	 */
 	private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException, SQLException {
-		if ( TRACE_ENABLED ) {
+		if ( log.isTraceEnabled() ) {
 			log.tracef( "Deserializing Session [%s]", getSessionIdentifier() );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/jpa/event/internal/CallbackBuilderLegacyImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/event/internal/CallbackBuilderLegacyImpl.java
@@ -53,7 +53,6 @@ final class CallbackBuilderLegacyImpl implements CallbackBuilder {
 
 	@Override
 	public void buildCallbacksForEntity(String entityClassName, CallbackRegistrar callbackRegistrar) {
-		final boolean debugEnabled = log.isDebugEnabled();
 		try {
 			final XClass entityXClass = reflectionManager.classForName( entityClassName );
 			final Class entityClass = reflectionManager.toClass( entityXClass );
@@ -61,7 +60,7 @@ final class CallbackBuilderLegacyImpl implements CallbackBuilder {
 				if ( callbackRegistrar.hasRegisteredCallbacks( entityClass, callbackType ) ) {
 					// this most likely means we have a class mapped multiple times using the hbm.xml
 					// "entity name" feature
-					if ( debugEnabled ) {
+					if ( log.isDebugEnabled() ) {
 						log.debugf(
 								"CallbackRegistry reported that Class [%s] already had %s callbacks registered; " +
 										"assuming this means the class was mapped twice " +
@@ -116,7 +115,6 @@ final class CallbackBuilderLegacyImpl implements CallbackBuilder {
 		XClass currentClazz = beanClass;
 		boolean stopListeners = false;
 		boolean stopDefaultListeners = false;
-		final boolean debugEnabled = log.isDebugEnabled();
 		do {
 			Callback callback = null;
 			List<XMethod> methods = currentClazz.getDeclaredMethods();
@@ -137,7 +135,7 @@ final class CallbackBuilderLegacyImpl implements CallbackBuilder {
 								);
 							}
 							ReflectHelper.ensureAccessibility( method );
-							if ( debugEnabled ) {
+							if ( log.isDebugEnabled() ) {
 								log.debugf(
 										"Adding %s as %s callback for entity %s",
 										methodName,
@@ -213,7 +211,7 @@ final class CallbackBuilderLegacyImpl implements CallbackBuilder {
 									);
 								}
 								ReflectHelper.ensureAccessibility( method );
-								if ( debugEnabled ) {
+								if ( log.isDebugEnabled() ) {
 									log.debugf(
 											"Adding %s as %s callback for entity %s",
 											methodName,
@@ -245,7 +243,6 @@ final class CallbackBuilderLegacyImpl implements CallbackBuilder {
 		final String embeddableClassName = embeddableProperty.getType().getReturnedClass().getName();
 		final XClass embeddableXClass = reflectionManager.classForName( embeddableClassName );
 		final Getter embeddableGetter = embeddableProperty.getGetter( entityClass );
-		final boolean debugEnabled = log.isDebugEnabled();
 		final List<Callback> callbacks = new ArrayList<>();
 		final List<String> callbacksMethodNames = new ArrayList<>();
 		XClass currentClazz = embeddableXClass;
@@ -269,7 +266,7 @@ final class CallbackBuilderLegacyImpl implements CallbackBuilder {
 								);
 							}
 							ReflectHelper.ensureAccessibility( method );
-							if ( debugEnabled ) {
+							if ( log.isDebugEnabled() ) {
 								log.debugf(
 										"Adding %s as %s callback for entity %s",
 										methodName,

--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -101,7 +101,6 @@ public abstract class Loader {
 	public static final String SELECT_DISTINCT = "select distinct";
 
 	protected static final CoreMessageLogger LOG = CoreLogging.messageLogger( Loader.class );
-	protected static final boolean DEBUG_ENABLED = LOG.isDebugEnabled();
 
 	private final SessionFactoryImplementor factory;
 	private volatile ColumnNameCache columnNameCache;
@@ -984,7 +983,7 @@ public abstract class Loader {
 		int count;
 
 		for ( count = 0; count < maxRows && rs.next(); count++ ) {
-			if ( DEBUG_ENABLED ) {
+			if ( LOG.isDebugEnabled() ) {
 				LOG.debugf( "Result set row: %s", count );
 			}
 			Object result = getRowFromResultSet(
@@ -1412,7 +1411,6 @@ public abstract class Loader {
 			final SharedSessionContractImplementor session) {
 
 		if ( keys != null ) {
-			final boolean debugEnabled = LOG.isDebugEnabled();
 			// this is a collection initializer, so we must create a collection
 			// for each of the passed-in keys, to account for the possibility
 			// that the collection is empty and has no rows in the result set
@@ -1420,7 +1418,7 @@ public abstract class Loader {
 			for ( CollectionPersister collectionPersister : collectionPersisters ) {
 				for ( Serializable key : keys ) {
 					//handle empty collections
-					if ( debugEnabled ) {
+					if ( LOG.isDebugEnabled() ) {
 						LOG.debugf(
 								"Result set contains (possibly empty) collection: %s",
 								MessageHelper.collectionInfoString( collectionPersister, key, getFactory() )
@@ -2140,7 +2138,7 @@ public abstract class Loader {
 			int columnSpan = typedValue.getType().getColumnSpan( getFactory() );
 			int[] locs = getNamedParameterLocs( name );
 			for ( int loc : locs ) {
-				if ( DEBUG_ENABLED ) {
+				if ( LOG.isDebugEnabled() ) {
 					LOG.debugf(
 							"bindNamedParameters() %s -> %s [%s]",
 							typedValue.getValue(),

--- a/hibernate-core/src/main/java/org/hibernate/loader/entity/CacheEntityLoaderHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/entity/CacheEntityLoaderHelper.java
@@ -52,8 +52,6 @@ public class CacheEntityLoaderHelper extends AbstractLockUpgradeEventListener {
 
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( CacheEntityLoaderHelper.class );
 
-	private static final boolean traceEnabled = LOG.isTraceEnabled();
-
 	public enum EntityStatus {
 		MANAGED,
 		REMOVED_ENTITY_MARKER,
@@ -274,7 +272,7 @@ public class CacheEntityLoaderHelper extends AbstractLockUpgradeEventListener {
 		final SessionFactoryImplementor factory = session.getFactory();
 		final EntityPersister subclassPersister;
 
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.tracef(
 					"Converting second-level cache entry [%s] into entity : %s",
 					entry,

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/AbstractLoadPlanBasedLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/AbstractLoadPlanBasedLoader.java
@@ -377,7 +377,6 @@ public abstract class AbstractLoadPlanBasedLoader {
 		if ( namedParams != null ) {
 			// assumes that types are all of span 1
 			final Iterator itr = namedParams.entrySet().iterator();
-			final boolean debugEnabled = log.isDebugEnabled();
 			int result = 0;
 			while ( itr.hasNext() ) {
 				final Map.Entry e = (Map.Entry) itr.next();
@@ -385,7 +384,7 @@ public abstract class AbstractLoadPlanBasedLoader {
 				final TypedValue typedval = (TypedValue) e.getValue();
 				final int[] locs = getNamedParameterLocs( name );
 				for ( int loc : locs ) {
-					if ( debugEnabled ) {
+					if ( log.isDebugEnabled() ) {
 						log.debugf(
 								"bindNamedParameters() %s -> %s [%s]",
 								typedval.getValue(),

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
@@ -200,8 +200,7 @@ class MetadataContext {
 
 	@SuppressWarnings({"unchecked"})
 	public void wrapUp() {
-		final boolean traceEnabled = LOG.isTraceEnabled();
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.trace( "Wrapping up metadata context..." );
 		}
 
@@ -213,7 +212,7 @@ class MetadataContext {
 			if ( PersistentClass.class.isAssignableFrom( mapping.getClass() ) ) {
 				@SuppressWarnings("unchecked")
 				final PersistentClass safeMapping = (PersistentClass) mapping;
-				if ( traceEnabled ) {
+				if ( LOG.isTraceEnabled() ) {
 					LOG.trace( "Starting entity [" + safeMapping.getEntityName() + ']' );
 				}
 				try {
@@ -248,7 +247,7 @@ class MetadataContext {
 					}
 				}
 				finally {
-					if ( traceEnabled ) {
+					if ( LOG.isTraceEnabled() ) {
 						LOG.trace( "Completed entity [" + safeMapping.getEntityName() + ']' );
 					}
 				}
@@ -256,7 +255,7 @@ class MetadataContext {
 			else if ( MappedSuperclass.class.isAssignableFrom( mapping.getClass() ) ) {
 				@SuppressWarnings("unchecked")
 				final MappedSuperclass safeMapping = (MappedSuperclass) mapping;
-				if ( traceEnabled ) {
+				if ( LOG.isTraceEnabled() ) {
 					LOG.trace( "Starting mapped superclass [" + safeMapping.getMappedClass().getName() + ']' );
 				}
 				try {
@@ -284,7 +283,7 @@ class MetadataContext {
 					}
 				}
 				finally {
-					if ( traceEnabled ) {
+					if ( LOG.isTraceEnabled() ) {
 						LOG.trace( "Completed mapped superclass [" + safeMapping.getMappedClass().getName() + ']' );
 					}
 				}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -3423,8 +3423,7 @@ public abstract class AbstractEntityPersister
 			);
 		}
 
-		final boolean traceEnabled = LOG.isTraceEnabled();
-		if ( traceEnabled ) {
+		if ( LOG.isTraceEnabled() ) {
 			LOG.tracev( "Deleting entity: {0}", MessageHelper.infoString( this, id, getFactory() ) );
 			if ( useVersion ) {
 				LOG.tracev( "Version: {0}", version );
@@ -3432,7 +3431,7 @@ public abstract class AbstractEntityPersister
 		}
 
 		if ( isTableCascadeDeleteEnabled( j ) ) {
-			if ( traceEnabled ) {
+			if ( LOG.isTraceEnabled() ) {
 				LOG.tracev( "Delete handled by foreign key constraint: {0}", getTableName( j ) );
 			}
 			return; //EARLY EXIT!

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/BasicBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/BasicBinder.java
@@ -47,9 +47,8 @@ public abstract class BasicBinder<J> implements ValueBinder<J> {
 
 	@Override
 	public final void bind(PreparedStatement st, J value, int index, WrapperOptions options) throws SQLException {
-		final boolean traceEnabled = log.isTraceEnabled();
 		if ( value == null ) {
-			if ( traceEnabled ) {
+			if ( log.isTraceEnabled() ) {
 				log.trace(
 						String.format(
 								NULL_BIND_MSG_TEMPLATE,
@@ -61,7 +60,7 @@ public abstract class BasicBinder<J> implements ValueBinder<J> {
 			st.setNull( index, sqlDescriptor.getSqlType() );
 		}
 		else {
-			if ( traceEnabled ) {
+			if ( log.isTraceEnabled() ) {
 				log.trace(
 						String.format(
 								BIND_MSG_TEMPLATE,
@@ -77,9 +76,8 @@ public abstract class BasicBinder<J> implements ValueBinder<J> {
 
 	@Override
 	public final void bind(CallableStatement st, J value, String name, WrapperOptions options) throws SQLException {
-		final boolean traceEnabled = log.isTraceEnabled();
 		if ( value == null ) {
-			if ( traceEnabled ) {
+			if ( log.isTraceEnabled() ) {
 				log.trace(
 						String.format(
 								NULL_BIND_MSG_TEMPLATE,
@@ -91,7 +89,7 @@ public abstract class BasicBinder<J> implements ValueBinder<J> {
 			st.setNull( name, sqlDescriptor.getSqlType() );
 		}
 		else {
-			if ( traceEnabled ) {
+			if ( log.isTraceEnabled() ) {
 				log.trace(
 						String.format(
 								BIND_MSG_TEMPLATE,

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/BasicExtractor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/BasicExtractor.java
@@ -45,9 +45,8 @@ public abstract class BasicExtractor<J> implements ValueExtractor<J> {
 	@Override
 	public J extract(ResultSet rs, String name, WrapperOptions options) throws SQLException {
 		final J value = doExtract( rs, name, options );
-		final boolean traceEnabled = log.isTraceEnabled();
 		if ( value == null || rs.wasNull() ) {
-			if ( traceEnabled ) {
+			if ( log.isTraceEnabled() ) {
 				log.tracef(
 						"extracted value ([%s] : [%s]) - [null]",
 						name,
@@ -57,7 +56,7 @@ public abstract class BasicExtractor<J> implements ValueExtractor<J> {
 			return null;
 		}
 		else {
-			if ( traceEnabled ) {
+			if ( log.isTraceEnabled() ) {
 				log.tracef(
 						"extracted value ([%s] : [%s]) - [%s]",
 						name,
@@ -88,9 +87,8 @@ public abstract class BasicExtractor<J> implements ValueExtractor<J> {
 	@Override
 	public J extract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
 		final J value = doExtract( statement, index, options );
-		final boolean traceEnabled = log.isTraceEnabled();
 		if ( value == null || statement.wasNull() ) {
-			if ( traceEnabled ) {
+			if ( log.isTraceEnabled() ) {
 				log.tracef(
 						"extracted procedure output  parameter ([%s] : [%s]) - [null]",
 						index,
@@ -100,7 +98,7 @@ public abstract class BasicExtractor<J> implements ValueExtractor<J> {
 			return null;
 		}
 		else {
-			if ( traceEnabled ) {
+			if ( log.isTraceEnabled() ) {
 				log.tracef(
 						"extracted procedure output  parameter ([%s] : [%s]) - [%s]",
 						index,
@@ -135,9 +133,8 @@ public abstract class BasicExtractor<J> implements ValueExtractor<J> {
 		}
 		final String paramName = paramNames[0];
 		final J value = doExtract( statement, paramName, options );
-		final boolean traceEnabled = log.isTraceEnabled();
 		if ( value == null || statement.wasNull() ) {
-			if ( traceEnabled ) {
+			if ( log.isTraceEnabled() ) {
 				log.tracef(
 						"extracted named procedure output  parameter ([%s] : [%s]) - [null]",
 						paramName,
@@ -147,7 +144,7 @@ public abstract class BasicExtractor<J> implements ValueExtractor<J> {
 			return null;
 		}
 		else {
-			if ( traceEnabled ) {
+			if ( log.isTraceEnabled() ) {
 				log.tracef(
 						"extracted named procedure output  parameter ([%s] : [%s]) - [%s]",
 						paramName,


### PR DESCRIPTION
Mirror of hibernate hibernate-orm#2892
Historically some classes have cached the logger level in static fields to prevent calls to the logging framework to reolve logging levels at run time.

Caching the log level at build time can cause a race condition in log levels at runtime, especially when the build system is multi-tiered. This is evident in a Quarkus native binary, as an incorrect log level at runtime;

https://github.com/quarkusio/quarkus/issues/2223

Optimisations in logging frameworks now mean that there is not a performance penalty for checking log level defined in the logging framework, removing the need to cache the log level.
