### PR TITLE
Mirror of hibernate hibernate-orm#2888

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -1164,12 +1164,15 @@ public interface Session extends SharedSessionContract, EntityManager, Hibernate
 	@Override
 	<T> org.hibernate.query.Query<T> createQuery(String queryString, Class<T> resultType);
 
+	// Override the JPA return type with the one exposed in QueryProducer
 	@Override
 	<T> org.hibernate.query.Query<T> createQuery(CriteriaQuery<T> criteriaQuery);
 
+	// Override the JPA return type with the one exposed in QueryProducer
 	@Override
 	org.hibernate.query.Query createQuery(CriteriaUpdate updateQuery);
 
+	// Override the JPA return type with the one exposed in QueryProducer
 	@Override
 	org.hibernate.query.Query createQuery(CriteriaDelete deleteQuery);
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.UUID;
 import javax.persistence.FlushModeType;
 import javax.persistence.TransactionRequiredException;
+import javax.persistence.criteria.Selection;
 
 import org.hibernate.CacheMode;
 import org.hibernate.Criteria;
@@ -30,8 +31,10 @@ import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.query.spi.sql.NativeSQLQuerySpecification;
 import org.hibernate.internal.util.config.ConfigurationHelper;
+import org.hibernate.jpa.spi.HibernateEntityManagerImplementor;
 import org.hibernate.loader.custom.CustomQuery;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.spi.QueryProducerImplementor;
 import org.hibernate.query.spi.ScrollableResultsImplementor;
 import org.hibernate.resource.jdbc.spi.JdbcSessionOwner;
@@ -479,4 +482,16 @@ public interface SharedSessionContractImplementor
 			) :
 			sessionJdbcBatchSize;
 	}
+
+	/**
+	 * @deprecated (since 5.2) - see deprecation note on
+	 * org.hibernate.jpa.spi.HibernateEntityManagerImplementor#createQuery(java.lang.String, java.lang.Class, javax.persistence.criteria.Selection, org.hibernate.jpa.spi.HibernateEntityManagerImplementor.QueryOptions)
+	 * @return The typed query
+	 */
+	@Deprecated
+	<T> QueryImplementor<T> createQuery(
+			String jpaqlString,
+			Class<T> resultClass,
+			Selection selection,
+			HibernateEntityManagerImplementor.QueryOptions queryOptions);
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -17,6 +17,10 @@ import java.util.UUID;
 import javax.persistence.FlushModeType;
 import javax.persistence.TransactionRequiredException;
 import javax.persistence.Tuple;
+import javax.persistence.criteria.CriteriaDelete;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.CriteriaUpdate;
+import javax.persistence.criteria.Selection;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.CacheMode;
@@ -63,6 +67,8 @@ import org.hibernate.engine.transaction.internal.TransactionImpl;
 import org.hibernate.engine.transaction.spi.TransactionImplementor;
 import org.hibernate.id.uuid.StandardRandomStrategy;
 import org.hibernate.jpa.internal.util.FlushModeTypeHelper;
+import org.hibernate.jpa.spi.CriteriaQueryTupleTransformer;
+import org.hibernate.jpa.spi.HibernateEntityManagerImplementor;
 import org.hibernate.jpa.spi.NativeQueryTupleTransformer;
 import org.hibernate.jpa.spi.TupleBuilderTransformer;
 import org.hibernate.persister.entity.EntityPersister;
@@ -71,6 +77,9 @@ import org.hibernate.procedure.ProcedureCallMemento;
 import org.hibernate.procedure.internal.ProcedureCallImpl;
 import org.hibernate.query.ParameterMetadata;
 import org.hibernate.query.Query;
+import org.hibernate.query.criteria.internal.compile.CompilableCriteria;
+import org.hibernate.query.criteria.internal.compile.CriteriaCompiler;
+import org.hibernate.query.criteria.internal.expression.CompoundSelectionImpl;
 import org.hibernate.query.internal.NativeQueryImpl;
 import org.hibernate.query.internal.QueryImpl;
 import org.hibernate.query.spi.NativeQueryImplementor;
@@ -726,6 +735,83 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		}
 		catch (RuntimeException e) {
 			markForRollbackOnly();
+			throw exceptionConverter.convert( e );
+		}
+	}
+
+	private CriteriaCompiler criteriaCompiler;
+
+	@SuppressWarnings("WeakerAccess")
+	protected CriteriaCompiler criteriaCompiler() {
+		if ( criteriaCompiler == null ) {
+			criteriaCompiler = new CriteriaCompiler( this );
+		}
+		return criteriaCompiler;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> QueryImplementor<T> createQuery(CriteriaQuery<T> criteriaQuery) {
+		checkOpen();
+		try {
+			return (QueryImplementor<T>) criteriaCompiler().compile( (CompilableCriteria) criteriaQuery );
+		}
+		catch ( RuntimeException e ) {
+			throw exceptionConverter.convert( e );
+		}
+	}
+
+	@Override
+	public QueryImplementor createQuery(CriteriaUpdate criteriaUpdate) {
+		checkOpen();
+		try {
+			return criteriaCompiler().compile( (CompilableCriteria) criteriaUpdate );
+		}
+		catch ( RuntimeException e ) {
+			throw exceptionConverter.convert( e );
+		}
+	}
+
+	@Override
+	public QueryImplementor createQuery(CriteriaDelete criteriaDelete) {
+		checkOpen();
+		try {
+			return criteriaCompiler().compile( (CompilableCriteria) criteriaDelete );
+		}
+		catch ( RuntimeException e ) {
+			throw exceptionConverter.convert( e );
+		}
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> QueryImplementor<T> createQuery(
+			String jpaqlString,
+			Class<T> resultClass,
+			Selection selection,
+			HibernateEntityManagerImplementor.QueryOptions queryOptions) {
+		try {
+			final QueryImplementor query = createQuery( jpaqlString );
+
+			if ( queryOptions.getValueHandlers() == null ) {
+				if ( queryOptions.getResultMetadataValidator() != null ) {
+					queryOptions.getResultMetadataValidator().validate( query.getReturnTypes() );
+				}
+			}
+
+			// determine if we need a result transformer
+			List tupleElements = Tuple.class.equals( resultClass )
+					? ( (CompoundSelectionImpl<Tuple>) selection ).getCompoundSelectionItems()
+					: null;
+			if ( queryOptions.getValueHandlers() != null || tupleElements != null ) {
+				query.setResultTransformer(
+						new CriteriaQueryTupleTransformer( queryOptions.getValueHandlers(), tupleElements )
+				);
+			}
+
+			return query;
+		}
+		catch ( RuntimeException e ) {
 			throw exceptionConverter.convert( e );
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -39,12 +39,7 @@ import javax.persistence.PersistenceException;
 import javax.persistence.PessimisticLockScope;
 import javax.persistence.StoredProcedureQuery;
 import javax.persistence.TransactionRequiredException;
-import javax.persistence.Tuple;
 import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaDelete;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.CriteriaUpdate;
-import javax.persistence.criteria.Selection;
 
 import org.hibernate.CacheMode;
 import org.hibernate.Criteria;
@@ -154,7 +149,6 @@ import org.hibernate.jpa.internal.util.CacheModeHelper;
 import org.hibernate.jpa.internal.util.ConfigurationHelper;
 import org.hibernate.jpa.internal.util.FlushModeTypeHelper;
 import org.hibernate.jpa.internal.util.LockModeTypeHelper;
-import org.hibernate.jpa.spi.CriteriaQueryTupleTransformer;
 import org.hibernate.jpa.spi.HibernateEntityManagerImplementor;
 import org.hibernate.loader.criteria.CriteriaLoader;
 import org.hibernate.loader.custom.CustomLoader;
@@ -173,11 +167,7 @@ import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.LazyInitializer;
 import org.hibernate.query.ImmutableEntityUpdateQueryHandlingMode;
 import org.hibernate.query.Query;
-import org.hibernate.query.criteria.internal.compile.CompilableCriteria;
-import org.hibernate.query.criteria.internal.compile.CriteriaCompiler;
-import org.hibernate.query.criteria.internal.expression.CompoundSelectionImpl;
 import org.hibernate.query.internal.CollectionFilterImpl;
-import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.spi.ScrollableResultsImplementor;
 import org.hibernate.resource.transaction.TransactionRequiredForJoinException;
 import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorImpl;
@@ -3461,39 +3451,6 @@ public final class SessionImpl
 		}
 	}
 
-	@Override
-	@SuppressWarnings("unchecked")
-	public <T> QueryImplementor<T> createQuery(
-			String jpaqlString,
-			Class<T> resultClass,
-			Selection selection,
-			QueryOptions queryOptions) {
-		try {
-			final QueryImplementor query = createQuery( jpaqlString );
-
-			if ( queryOptions.getValueHandlers() == null ) {
-				if ( queryOptions.getResultMetadataValidator() != null ) {
-					queryOptions.getResultMetadataValidator().validate( query.getReturnTypes() );
-				}
-			}
-
-			// determine if we need a result transformer
-			List tupleElements = Tuple.class.equals( resultClass )
-					? ( (CompoundSelectionImpl<Tuple>) selection ).getCompoundSelectionItems()
-					: null;
-			if ( queryOptions.getValueHandlers() != null || tupleElements != null ) {
-				query.setResultTransformer(
-						new CriteriaQueryTupleTransformer( queryOptions.getValueHandlers(), tupleElements )
-				);
-			}
-
-			return query;
-		}
-		catch ( RuntimeException e ) {
-			throw exceptionConverter.convert( e );
-		}
-	}
-
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// EntityManager impl
@@ -3748,50 +3705,6 @@ public final class SessionImpl
 	@Override
 	public Map<String, Object> getProperties() {
 		return Collections.unmodifiableMap( properties );
-	}
-
-	private CriteriaCompiler criteriaCompiler;
-
-	@SuppressWarnings("WeakerAccess")
-	protected CriteriaCompiler criteriaCompiler() {
-		if ( criteriaCompiler == null ) {
-			criteriaCompiler = new CriteriaCompiler( this );
-		}
-		return criteriaCompiler;
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public <T> QueryImplementor<T> createQuery(CriteriaQuery<T> criteriaQuery) {
-		checkOpen();
-		try {
-			return (QueryImplementor<T>) criteriaCompiler().compile( (CompilableCriteria) criteriaQuery );
-		}
-		catch ( RuntimeException e ) {
-			throw exceptionConverter.convert( e );
-		}
-	}
-
-	@Override
-	public QueryImplementor createQuery(CriteriaUpdate criteriaUpdate) {
-		checkOpen();
-		try {
-			return criteriaCompiler().compile( (CompilableCriteria) criteriaUpdate );
-		}
-		catch ( RuntimeException e ) {
-			throw exceptionConverter.convert( e );
-		}
-	}
-
-	@Override
-	public QueryImplementor createQuery(CriteriaDelete criteriaDelete) {
-		checkOpen();
-		try {
-			return criteriaCompiler().compile( (CompilableCriteria) criteriaDelete );
-		}
-		catch ( RuntimeException e ) {
-			throw exceptionConverter.convert( e );
-		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
@@ -8,6 +8,10 @@ package org.hibernate.query;
 
 import org.hibernate.SQLQuery;
 
+import javax.persistence.criteria.CriteriaDelete;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.CriteriaUpdate;
+
 /**
  * Contract for things that can produce Query instances.  Expected implementors include
  * Session and StatelessSession.
@@ -163,4 +167,10 @@ public interface QueryProducer {
 	 * @return The NativeQuery instance for manipulation and execution
 	 */
 	NativeQuery getNamedNativeQuery(String name);
+
+	<T> Query<T> createQuery(CriteriaQuery<T> criteriaQuery);
+
+	Query createQuery(CriteriaUpdate updateQuery);
+
+	Query createQuery(CriteriaDelete deleteQuery);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/AbstractManipulationCriteriaQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/AbstractManipulationCriteriaQuery.java
@@ -17,6 +17,7 @@ import javax.persistence.criteria.Subquery;
 import javax.persistence.metamodel.EntityType;
 
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.jpa.spi.HibernateEntityManagerImplementor;
 import org.hibernate.query.criteria.internal.compile.CompilableCriteria;
 import org.hibernate.query.criteria.internal.compile.CriteriaInterpretation;
@@ -105,7 +106,7 @@ public abstract class AbstractManipulationCriteriaQuery<T> implements Compilable
 			@Override
 			@SuppressWarnings("unchecked")
 			public QueryImplementor buildCompiledQuery(
-					SessionImplementor entityManager,
+					SharedSessionContractImplementor entityManager,
 					final InterpretedParameterMetadata interpretedParameterMetadata) {
 
 				final Map<String,Class> implicitParameterTypes = extractTypeMap( interpretedParameterMetadata.implicitParameterBindings() );

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/CriteriaQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/CriteriaQueryImpl.java
@@ -24,7 +24,7 @@ import javax.persistence.criteria.Selection;
 import javax.persistence.criteria.Subquery;
 import javax.persistence.metamodel.EntityType;
 
-import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.jpa.spi.HibernateEntityManagerImplementor;
 import org.hibernate.query.criteria.internal.compile.CompilableCriteria;
 import org.hibernate.query.criteria.internal.compile.CriteriaInterpretation;
@@ -302,7 +302,7 @@ public class CriteriaQueryImpl<T> extends AbstractNode implements CriteriaQuery<
 			@Override
 			@SuppressWarnings("unchecked")
 			public QueryImplementor buildCompiledQuery(
-					SessionImplementor entityManager,
+					SharedSessionContractImplementor entityManager,
 					final InterpretedParameterMetadata parameterMetadata) {
 
 				final Map<String,Class> implicitParameterTypes = extractTypeMap( parameterMetadata.implicitParameterBindings() );

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/compile/CriteriaCompiler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/compile/CriteriaCompiler.java
@@ -14,11 +14,10 @@ import java.util.Map;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.ParameterExpression;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.collections.Stack;
 import org.hibernate.internal.util.collections.StandardStack;
@@ -38,9 +37,9 @@ import org.hibernate.type.Type;
  * @author Steve Ebersole
  */
 public class CriteriaCompiler implements Serializable {
-	private final SessionImplementor entityManager;
+	private final SharedSessionContractImplementor entityManager;
 
-	public CriteriaCompiler(SessionImplementor entityManager) {
+	public CriteriaCompiler(SharedSessionContractImplementor entityManager) {
 		this.entityManager = entityManager;
 	}
 
@@ -55,7 +54,7 @@ public class CriteriaCompiler implements Serializable {
 		final Map<ParameterExpression<?>, ExplicitParameterInfo<?>> explicitParameterInfoMap = new HashMap<>();
 		final List<ImplicitParameterBinding> implicitParameterBindings = new ArrayList<>();
 
-		final SessionFactoryImplementor sessionFactory = entityManager.getSessionFactory();
+		final SessionFactoryImplementor sessionFactory = entityManager.getFactory();
 
 		final LiteralHandlingMode criteriaLiteralHandlingMode = sessionFactory
 				.getSessionFactoryOptions()

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/compile/CriteriaInterpretation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/compile/CriteriaInterpretation.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.query.criteria.internal.compile;
 
-import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.spi.QueryImplementor;
 
 /**
@@ -25,5 +25,5 @@ public interface CriteriaInterpretation {
 	 *
 	 * @return The created Query instance.
 	 */
-	QueryImplementor buildCompiledQuery(SessionImplementor entityManager, InterpretedParameterMetadata interpretedParameterMetadata);
+	QueryImplementor buildCompiledQuery(SharedSessionContractImplementor entityManager, InterpretedParameterMetadata interpretedParameterMetadata);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/compile/CriteriaQueryTypeQueryAdapter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/compile/CriteriaQueryTypeQueryAdapter.java
@@ -36,7 +36,7 @@ import org.hibernate.Query;
 import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.engine.spi.RowSelection;
-import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.query.ParameterMetadata;
@@ -59,12 +59,12 @@ import org.hibernate.type.Type;
  * @author Steve Ebersole
  */
 public class CriteriaQueryTypeQueryAdapter<X> implements QueryImplementor<X> {
-	private final SessionImplementor entityManager;
+	private final SharedSessionContractImplementor entityManager;
 	private final QueryImplementor<X> jpqlQuery;
 	private final Map<ParameterExpression<?>, ExplicitParameterInfo<?>> explicitParameterInfoMap;
 
 	public CriteriaQueryTypeQueryAdapter(
-			SessionImplementor entityManager,
+			SharedSessionContractImplementor entityManager,
 			QueryImplementor<X> jpqlQuery,
 			Map<ParameterExpression<?>, ExplicitParameterInfo<?>> explicitParameterInfoMap) {
 		this.entityManager = entityManager;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/BasicCriteriaExecutionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/BasicCriteriaExecutionTests.java
@@ -43,6 +43,21 @@ public class BasicCriteriaExecutionTests extends BaseNonConfigCoreFunctionalTest
 	}
 
 	@Test
+	public void testExecutingBasicCriteriaQueryInStatelessSession() {
+		final CriteriaBuilder criteriaBuilder = sessionFactory().getCriteriaBuilder();
+
+		final CriteriaQuery<Object> criteria = criteriaBuilder.createQuery();
+
+		final Root<BasicEntity> root = criteria.from( BasicEntity.class );
+
+		criteria.select( root );
+
+		inStatelessSession(
+				session -> session.createQuery( criteria ).list()
+		);
+	}
+
+	@Test
 	public void testExecutingBasicCriteriaQueryLiteralPredicate() {
 		final CriteriaBuilder criteriaBuilder = sessionFactory().getCriteriaBuilder();
 
@@ -55,6 +70,23 @@ public class BasicCriteriaExecutionTests extends BaseNonConfigCoreFunctionalTest
 		criteria.where( criteriaBuilder.equal( criteriaBuilder.literal( 1 ), criteriaBuilder.literal( 1 ) ) );
 
 		inSession(
+				session -> session.createQuery( criteria ).list()
+		);
+	}
+
+	@Test
+	public void testExecutingBasicCriteriaQueryLiteralPredicateInStatelessSession() {
+		final CriteriaBuilder criteriaBuilder = sessionFactory().getCriteriaBuilder();
+
+		final CriteriaQuery<Object> criteria = criteriaBuilder.createQuery();
+
+		final Root<BasicEntity> root = criteria.from( BasicEntity.class );
+
+		criteria.select( root );
+
+		criteria.where( criteriaBuilder.equal( criteriaBuilder.literal( 1 ), criteriaBuilder.literal( 1 ) ) );
+
+		inStatelessSession(
 				session -> session.createQuery( criteria ).list()
 		);
 	}
@@ -74,6 +106,25 @@ public class BasicCriteriaExecutionTests extends BaseNonConfigCoreFunctionalTest
 		criteria.where( criteriaBuilder.equal( param, param ) );
 
 		inSession(
+				session -> session.createQuery( criteria ).setParameter( param, 1 ).list()
+		);
+	}
+
+	@Test
+	public void testExecutingBasicCriteriaQueryParameterPredicateInStatelessSession() {
+		final CriteriaBuilder criteriaBuilder = sessionFactory().getCriteriaBuilder();
+
+		final CriteriaQuery<Object> criteria = criteriaBuilder.createQuery();
+
+		final Root<BasicEntity> root = criteria.from( BasicEntity.class );
+
+		criteria.select( root );
+
+		final ParameterExpression<Integer> param = criteriaBuilder.parameter( Integer.class );
+
+		criteria.where( criteriaBuilder.equal( param, param ) );
+
+		inStatelessSession(
 				session -> session.createQuery( criteria ).setParameter( param, 1 ).list()
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/BasicCriteriaExecutionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/BasicCriteriaExecutionTests.java
@@ -1,0 +1,89 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.query.criteria;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.ParameterExpression;
+import javax.persistence.criteria.Root;
+
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+/**
+ * @author Steve Ebersole
+ */
+public class BasicCriteriaExecutionTests extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] { BasicEntity.class };
+	}
+
+	@Test
+	public void testExecutingBasicCriteriaQuery() {
+		final CriteriaBuilder criteriaBuilder = sessionFactory().getCriteriaBuilder();
+
+		final CriteriaQuery<Object> criteria = criteriaBuilder.createQuery();
+
+		final Root<BasicEntity> root = criteria.from( BasicEntity.class );
+
+		criteria.select( root );
+
+		inSession(
+				session -> session.createQuery( criteria ).list()
+		);
+	}
+
+	@Test
+	public void testExecutingBasicCriteriaQueryLiteralPredicate() {
+		final CriteriaBuilder criteriaBuilder = sessionFactory().getCriteriaBuilder();
+
+		final CriteriaQuery<Object> criteria = criteriaBuilder.createQuery();
+
+		final Root<BasicEntity> root = criteria.from( BasicEntity.class );
+
+		criteria.select( root );
+
+		criteria.where( criteriaBuilder.equal( criteriaBuilder.literal( 1 ), criteriaBuilder.literal( 1 ) ) );
+
+		inSession(
+				session -> session.createQuery( criteria ).list()
+		);
+	}
+
+	@Test
+	public void testExecutingBasicCriteriaQueryParameterPredicate() {
+		final CriteriaBuilder criteriaBuilder = sessionFactory().getCriteriaBuilder();
+
+		final CriteriaQuery<Object> criteria = criteriaBuilder.createQuery();
+
+		final Root<BasicEntity> root = criteria.from( BasicEntity.class );
+
+		criteria.select( root );
+
+		final ParameterExpression<Integer> param = criteriaBuilder.parameter( Integer.class );
+
+		criteria.where( criteriaBuilder.equal( param, param ) );
+
+		inSession(
+				session -> session.createQuery( criteria ).setParameter( param, 1 ).list()
+		);
+	}
+
+	@Entity
+	public static class BasicEntity {
+
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+	}
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
@@ -20,6 +20,7 @@ import javax.persistence.SharedCacheMode;
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
 import org.hibernate.Session;
+import org.hibernate.StatelessSession;
 import org.hibernate.Transaction;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl;
 import org.hibernate.boot.registry.BootstrapServiceRegistry;
@@ -516,5 +517,9 @@ public abstract class BaseCoreFunctionalTestCase extends BaseUnitTestCase {
 
 	protected void inSession(Consumer<SessionImplementor> action) {
 		TransactionUtil2.inSession( sessionFactory(), action );
+	}
+
+	protected void inStatelessSession(Consumer<StatelessSession> action) {
+		TransactionUtil2.inStatelessSession( sessionFactory(), action );
 	}
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseNonConfigCoreFunctionalTestCase.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseNonConfigCoreFunctionalTestCase.java
@@ -20,6 +20,7 @@ import java.util.function.Consumer;
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
 import org.hibernate.Session;
+import org.hibernate.StatelessSession;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataBuilder;
 import org.hibernate.boot.MetadataSources;
@@ -553,6 +554,10 @@ public class BaseNonConfigCoreFunctionalTestCase extends BaseUnitTestCase {
 	public void inSession(Consumer<SessionImplementor> action) {
 		log.trace( "#inSession(action)" );
 		TransactionUtil2.inSession( sessionFactory(), action );
+	}
+
+	public void inStatelessSession(Consumer<StatelessSession> action) {
+		TransactionUtil2.inStatelessSession( sessionFactory(), action );
 	}
 
 	public void inTransaction(Consumer<SessionImplementor> action) {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/transaction/TransactionUtil2.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/transaction/TransactionUtil2.java
@@ -8,6 +8,7 @@ package org.hibernate.testing.transaction;
 
 import java.util.function.Consumer;
 
+import org.hibernate.StatelessSession;
 import org.hibernate.Transaction;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
@@ -34,6 +35,18 @@ public class TransactionUtil2 {
 		}
 	}
 
+	public static void inStatelessSession(SessionFactoryImplementor sfi, Consumer<StatelessSession> action) {
+		log.trace( "#inStatelessSession(SF,action)" );
+
+		try (StatelessSession session = sfi.openStatelessSession()) {
+			log.trace( "StatelessSession opened, calling action" );
+			action.accept( session );
+			log.trace( "called action" );
+		}
+		finally {
+			log.trace( "StatelessSession closed (AutoCloseable)" );
+		}
+	}
 
 	public static void inTransaction(SessionFactoryImplementor factory, Consumer<SessionImplementor> action) {
 		log.trace( "#inTransaction(factory, action)");


### PR DESCRIPTION
Mirror of hibernate hibernate-orm#2888
https://hibernate.atlassian.net//browse/HHH-13154

This is necessary to allow users to prepare for ORM 6 where we will remove Hibernate Criteria in favor of JPA criteria.

I don't think it introduces any binary incompatibility. Adding <at>gbadner just in case you want to double-check.

This merely pulls up the `createQuery(criteria)` method declarations from `Session` to `QueryProducer` (to also expose it in `StatelessSession`) and implementations from `SessionImpl` to `AbstractSharedSessionContract` (to also implement it in `StatelessSessionImpl`).

I had to leave the method declarations in `Session` in order to resolve the conflict between signatures from `QueryProducer` and from `EntityManager`.

The tests are rather light, but there's no point in re-testing all the different criteria ("between", "eq", "asc", ...), since they are largely independent from the session. So I just backported a basic test from ORM 6.

I also checked that this allows to solve [HSEARCH-3447](https://hibernate.atlassian.net/browse/HSEARCH-3447)
