### PR TITLE
Mirror of hibernate hibernate-orm#2887

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 install:
   - ./gradlew assemble
 script:
-  - travis_wait 45 ./gradlew check
+  - ./gradlew check
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -215,6 +215,13 @@ test {
 	}
 }
 
+// Log a statement for each test, so that Travis doesn't end up panicking because when there's no output for a long time
+test {
+	testLogging {
+		events "passed", "skipped", "failed"
+	}
+}
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // IDE
 


### PR DESCRIPTION
Mirror of hibernate hibernate-orm#2887
... so that we get actionable logs when something fails.

Builds on master generally last about 26 minutes, which is well below the limit of 50 minutes: https://docs.travis-ci.com/user/customizing-the-build#build-timeouts

So we only need to comply with the requirement of not waiting more than 10 minutes between two outputs, which is mainly a problem with tests. I added some configuration so that Gradle logs one line per executed test.

It worked just fine for this execution: https://travis-ci.org/yrodiere/hibernate-orm/builds/537749346?utm_medium=notification&utm_source=email

The log is big (1.6MB), but still below the [4MB limit](https://docs.travis-ci.com/user/common-build-problems/#log-length-exceeded): https://api.travis-ci.org/v3/job/537749347/log.txt
