### PR TITLE
Mirror of hibernate hibernate-orm#2933

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/spi/BytecodeEnhancementMetadata.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/spi/BytecodeEnhancementMetadata.java
@@ -10,6 +10,7 @@ import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInter
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributesMetadata;
 import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
@@ -35,6 +36,14 @@ public interface BytecodeEnhancementMetadata {
 	boolean isEnhancedForLazyLoading();
 
 	LazyAttributesMetadata getLazyAttributesMetadata();
+
+	/**
+	 * Create an "enhancement as proxy" instance for the given entity
+	 *
+	 * @apiNote The `addEmptyEntry` parameter is used to avoid creation of `EntityEntry` instances when we
+	 * do not need them. - mainly from StatelessSession
+	 */
+	PersistentAttributeInterceptable createEnhancedProxy(EntityKey keyToLoad, boolean addEmptyEntry, SharedSessionContractImplementor session);
 
 	/**
 	 * Build and inject an interceptor instance into the enhanced entity.

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -746,6 +746,11 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	}
 
 	@Override
+	public void addEnhancedProxy(EntityKey key, PersistentAttributeInterceptable entity) {
+		entitiesByKey.put( key, entity );
+	}
+
+	@Override
 	public Object getCollectionOwner(Serializable key, CollectionPersister collectionPersister) throws MappingException {
 		// todo : we really just need to add a split in the notions of:
 		//		1) collection key

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/BatchFetchQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/BatchFetchQueue.java
@@ -127,12 +127,12 @@ public class BatchFetchQueue {
 	 */
 	public void addBatchLoadableEntityKey(EntityKey key) {
 		if ( key.isBatchLoadable() ) {
-			LinkedHashSet<EntityKey> set =  batchLoadableEntityKeys.get( key.getEntityName());
-			if (set == null) {
-				set = new LinkedHashSet<>( 8 );
-				batchLoadableEntityKeys.put( key.getEntityName(), set);
-			}
-			set.add(key);
+			final LinkedHashSet<EntityKey> keysForEntity = batchLoadableEntityKeys.computeIfAbsent(
+					key.getEntityName(),
+					k -> new LinkedHashSet<>( 8 )
+			);
+
+			keysForEntity.add( key );
 		}
 	}
 	

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistenceContext.java
@@ -345,6 +345,12 @@ public interface PersistenceContext {
 	Object proxyFor(Object impl) throws HibernateException;
 
 	/**
+	 * Cross between {@link #addEntity(EntityKey, Object)} and {@link #addProxy(EntityKey, Object)}
+	 * for use with enhancement-as-proxy
+	 */
+	void addEnhancedProxy(EntityKey key, PersistentAttributeInterceptable entity);
+
+	/**
 	 * Get the entity that owns this persistent collection
 	 */
 	Object getCollectionOwner(Serializable key, CollectionPersister collectionPersister)

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
@@ -292,31 +292,12 @@ public class DefaultLoadEventListener implements LoadEventListener {
 				}
 			}
 
+			// Potentially add a batch-fetch entry into the queue for this entity
+			persistenceContext.getBatchFetchQueue().addBatchLoadableEntityKey( keyToLoad );
+
 			// This is the crux of HHH-11147
 			// create the (uninitialized) entity instance - has only id set
-			final Object entity = persister.getEntityTuplizer().instantiate(
-					keyToLoad.getIdentifier(),
-					event.getSession()
-			);
-
-			// add the entity instance to the persistence context
-			persistenceContext.addEntity(
-					entity,
-					Status.MANAGED,
-					null,
-					keyToLoad,
-					null,
-					LockMode.NONE,
-					true,
-					persister,
-					true
-			);
-
-			persister.getEntityMetamodel()
-					.getBytecodeEnhancementMetadata()
-					.injectEnhancedEntityAsProxyInterceptor( entity, keyToLoad, event.getSession() );
-
-			return entity;
+			return persister.getBytecodeEnhancementMetadata().createEnhancedProxy( keyToLoad, true, event.getSession() );
 		}
 		else {
 			if ( persister.hasProxy() ) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -303,14 +303,7 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 
 				// we cannot use bytecode proxy for entities with subclasses
 				if ( !persister.getEntityMetamodel().hasSubclasses() ) {
-					final Object entity = persister.getEntityTuplizer().instantiate( id, this );
-
-					persister.getEntityMetamodel()
-							.getBytecodeEnhancementMetadata()
-							.injectEnhancedEntityAsProxyInterceptor( entity, entityKey, this );
-
-					getPersistenceContext().addEntity( entityKey, entity );
-					return entity;
+					return persister.getBytecodeEnhancementMetadata().createEnhancedProxy( entityKey, false, this );
 				}
 			}
 

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/BytecodeEnhancementMetadataNonPojoImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/BytecodeEnhancementMetadataNonPojoImpl.java
@@ -12,6 +12,7 @@ import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributesMetadata;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.bytecode.spi.NotInstrumentedException;
 import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
@@ -65,6 +66,11 @@ public class BytecodeEnhancementMetadataNonPojoImpl implements BytecodeEnhanceme
 			Object entity,
 			EntityKey entityKey,
 			SharedSessionContractImplementor session) {
+		throw new NotInstrumentedException( errorMsg );
+	}
+
+	@Override
+	public PersistentAttributeInterceptable createEnhancedProxy(EntityKey keyToLoad, boolean addEmptyEntry, SharedSessionContractImplementor session) {
 		throw new NotInstrumentedException( errorMsg );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/BytecodeEnhancementMetadataPojoImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/BytecodeEnhancementMetadataPojoImpl.java
@@ -6,9 +6,11 @@
  */
 package org.hibernate.tuple.entity;
 
+import java.io.Serializable;
 import java.util.Set;
 import java.util.function.Function;
 
+import org.hibernate.LockMode;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
@@ -19,7 +21,9 @@ import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.Status;
 import org.hibernate.mapping.PersistentClass;
+import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.type.CompositeType;
 
 /**
@@ -128,6 +132,45 @@ public class BytecodeEnhancementMetadataPojoImpl implements BytecodeEnhancementM
 	@Override
 	public LazyAttributeLoadingInterceptor extractInterceptor(Object entity) throws NotInstrumentedException {
 		return (LazyAttributeLoadingInterceptor) extractLazyInterceptor( entity );
+	}
+
+	@Override
+	public PersistentAttributeInterceptable createEnhancedProxy(EntityKey entityKey, boolean addEmptyEntry, SharedSessionContractImplementor session) {
+		final EntityPersister persister = entityKey.getPersister();
+		final Serializable identifier = entityKey.getIdentifier();
+
+		// first, instantiate the entity instance to use as the proxy
+		final PersistentAttributeInterceptable entity = (PersistentAttributeInterceptable) persister.getEntityTuplizer().instantiate( identifier, session );
+
+		// add the entity (proxy) instance to the PC
+		session.getPersistenceContext().addEnhancedProxy( entityKey, entity );
+
+		// if requested, add the "holder entry" to the PC
+		if ( addEmptyEntry ) {
+			session.getPersistenceContext().addEntry(
+					entity,
+					Status.MANAGED,
+					// loaded state
+					null,
+					// row-id
+					null,
+					identifier,
+					// version
+					null,
+					LockMode.NONE,
+					// we assume it exists in db
+					true,
+					persister,
+					true
+			);
+		}
+
+		// inject the interceptor
+		persister.getEntityMetamodel()
+				.getBytecodeEnhancementMetadata()
+				.injectEnhancedEntityAsProxyInterceptor( entity, entityKey, session );
+
+		return entity;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/BatchFetchProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/BatchFetchProxyTest.java
@@ -1,0 +1,186 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.bytecode.enhancement.lazy.proxy;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.Hibernate;
+import org.hibernate.Query;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.stat.Statistics;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Gail Badner
+ */
+
+@TestForIssue(jiraKey = "HHH-11147")
+@RunWith( BytecodeEnhancerRunner.class )
+@EnhancementOptions( lazyLoading = true )
+public class BatchFetchProxyTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	private static int NUMBER_OF_ENTITIES = 20;
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-11147")
+	public void testBatchAssociation() {
+		doInHibernate(
+				this::sessionFactory, session -> {
+					final Statistics statistics = sessionFactory().getStatistics();
+					statistics.clear();
+					List<Employee> employees = session.createQuery( "from Employee", Employee.class ).getResultList();
+
+					assertEquals( 1, statistics.getPrepareStatementCount() );
+					assertEquals( NUMBER_OF_ENTITIES, employees.size() );
+
+					for ( int i = 0 ; i < employees.size() ; i++ ) {
+						final Employer employer = employees.get( i ).employer;
+						if ( i % 10 == 0 ) {
+							assertFalse( Hibernate.isInitialized( employer ) );
+							Hibernate.initialize( employer );
+						}
+						else {
+							assertTrue( Hibernate.isInitialized( employer ) );
+						}
+						assertEquals( "Employer #" + employer.id, employer.name );
+					}
+
+					assertEquals( 3, statistics.getPrepareStatementCount() );
+				}
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-11147")
+	public void testBatchEntityLoad() {
+		doInHibernate(
+				this::sessionFactory, session -> {
+					final Statistics statistics = sessionFactory().getStatistics();
+					statistics.clear();
+
+					List<Employer> employers = new ArrayList<>();
+					for ( int i = 0 ; i < NUMBER_OF_ENTITIES ; i++ ) {
+						employers.add( session.load( Employer.class, i + 1) );
+					}
+
+					assertEquals( 0, statistics.getPrepareStatementCount() );
+
+					for ( int i = 0 ; i < NUMBER_OF_ENTITIES ; i++ ) {
+						final Employer employer = employers.get( i );
+						if ( i % 10 == 0 ) {
+							assertFalse( Hibernate.isInitialized( employer ) );
+							Hibernate.initialize( employer );
+						}
+						else {
+							assertTrue( Hibernate.isInitialized( employer ) );
+						}
+						assertEquals( "Employer #" + employer.id, employer.name );
+					}
+
+					assertEquals( 2, statistics.getPrepareStatementCount() );
+				}
+		);
+	}
+
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] {
+				Employee.class,
+				Employer.class
+		};
+	}
+
+	@Before
+	public void setUpData() {
+		doInHibernate(
+				this::sessionFactory, session -> {
+					for ( int i = 0 ; i < NUMBER_OF_ENTITIES ; i++ ) {
+						final Employee employee = new Employee();
+						employee.id = i + 1;
+						employee.name = "Employee #" + employee.id;
+						final Employer employer = new Employer();
+						employer.id = i + 1;
+						employer.name = "Employer #" + employer.id;
+						employee.employer = employer;
+						session.persist( employee );
+					}
+				}
+		);
+	}
+
+	@After
+	public void cleanupDate() {
+		doInHibernate(
+				this::sessionFactory, session -> {
+					session.createQuery( "delete from Employee" ).executeUpdate();
+					session.createQuery( "delete from Employer" ).executeUpdate();
+				}
+		);
+	}
+
+	@Override
+	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
+		super.configureStandardServiceRegistryBuilder( ssrb );
+		ssrb.applySetting( AvailableSettings.ALLOW_ENHANCEMENT_AS_PROXY, "true" );
+		ssrb.applySetting( AvailableSettings.FORMAT_SQL, "false" );
+		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
+	}
+
+	@Override
+	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
+		super.configureSessionFactoryBuilder( sfb );
+		sfb.applyStatisticsSupport( true );
+		sfb.applySecondLevelCacheSupport( false );
+		sfb.applyQueryCacheSupport( false );
+	}
+
+	@Entity(name = "Employee")
+	public static class Employee {
+		@Id
+		private int id;
+
+		private String name;
+
+		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		private Employer employer;
+	}
+
+	@Entity(name = "Employer")
+	@BatchSize(size = 10)
+	public static class Employer {
+		@Id
+		private int id;
+
+		private String name;
+	}
+}


### PR DESCRIPTION
Mirror of hibernate hibernate-orm#2933
Proposal for alternative approach to Gail and Andrea's work on this - so intended as an alternative to https://github.com/hibernate/hibernate-orm/pull/2931

At a high-level it centers on the addition of 2 methods - 

- org.hibernate.engine.spi.PersistenceContext#addEnhancedProxy
- org.hibernate.bytecode.spi.BytecodeEnhancementMetadata#createEnhancedProxy
