### PR TITLE
Mirror of hibernate hibernate-orm#2928

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/CopyIdentifierComponentSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/CopyIdentifierComponentSecondPass.java
@@ -196,7 +196,9 @@ public class CopyIdentifierComponentSecondPass implements SecondPass {
 				}
 				final String columnName = joinColumn == null || joinColumn.isNameDeferred() ? "tata_" + column.getName() : joinColumn
 						.getName();
-				value.addColumn( new Column( columnName ) );
+				final boolean insertable = joinColumn == null || joinColumn.isInsertable() ;
+				final boolean updatable = joinColumn == null || joinColumn.isUpdatable() ;
+				value.addColumn( new Column( columnName ), insertable, updatable );
 				if ( joinColumn != null ) {
 					applyComponentColumnSizeValueToJoinColumn( column, joinColumn );
 					joinColumn.linkWithValue( value );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/CopyIdentifierComponentSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/CopyIdentifierComponentSecondPass.java
@@ -196,8 +196,8 @@ public class CopyIdentifierComponentSecondPass implements SecondPass {
 				}
 				final String columnName = joinColumn == null || joinColumn.isNameDeferred() ? "tata_" + column.getName() : joinColumn
 						.getName();
-				final boolean insertable = joinColumn == null || joinColumn.isInsertable() ;
-				final boolean updatable = joinColumn == null || joinColumn.isUpdatable() ;
+				final boolean insertable = joinColumn == null || joinColumn.isInsertable();
+				final boolean updatable = joinColumn == null || joinColumn.isUpdatable();
 				value.addColumn( new Column( columnName ), insertable, updatable );
 				if ( joinColumn != null ) {
 					applyComponentColumnSizeValueToJoinColumn( column, joinColumn );


### PR DESCRIPTION
Mirror of hibernate hibernate-orm#2928
Different Behavior on "insertable" of "<at>JoinColumn" of "<at>OneToMany" field between Hibernate4/Hibernate5
First the 'joincolumn' was added to 'SampleValue' with default insertable/updatable as true and later while linking it with sampleValue, it was added again with overridden insertable and updatable values and hence the exception "Same column is added more than once with different values for isInsertable" was being thrown as it was already added with different values.
With this fix, while adding join column, insertable and updatable values are passed so that this exception does not arise.
