### PR TITLE
Mirror of hibernate hibernate-orm#3036

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,10 +11,6 @@ buildscript {
 	repositories {
 		jcenter()
 		mavenCentral()
-		maven {
-			name 'jboss-snapshots'
-			url 'http://repository.jboss.org/nexus/content/repositories/snapshots/'
-		}
 	}
 	dependencies {
 		classpath 'org.hibernate.build.gradle:gradle-maven-publish-auth:2.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -36,10 +36,6 @@ plugins {
 allprojects {
 	repositories {
 		mavenCentral()
-		maven {
-			name "jboss-snapshots"
-			url "http://repository.jboss.org/nexus/content/repositories/snapshots/"
-		}
 		//Allow loading additional dependencies from a local path;
 		//useful to load JDBC drivers which can not be distributed in public.
 		if (System.env['ADDITIONAL_REPO'] != null) {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,14 +7,6 @@
 repositories {
 	mavenCentral()
 	jcenter()
-	maven {
-		name 'jboss-releases'
-		url 'http://repository.jboss.org/nexus/content/repositories/releases/'
-	}
-	maven {
-		name 'jboss-snapshots'
-		url 'http://repository.jboss.org/nexus/content/repositories/snapshots/'
-	}
 }
 
 apply plugin: "groovy"

--- a/documentation/src/main/asciidoc/topical/wildfly/Wildfly.adoc
+++ b/documentation/src/main/asciidoc/topical/wildfly/Wildfly.adoc
@@ -209,7 +209,7 @@ repositories {
 	mavenCentral()
 	maven {
 		name 'jboss-public'
-		url 'http://repository.jboss.org/nexus/content/groups/public/'
+		url 'https://repository.jboss.org/nexus/content/groups/public/'
 	}
 }
 

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -82,7 +82,6 @@ dependencies {
 	testRuntime( libraries.log4j )
 	testRuntime( libraries.javassist )
 	testRuntime( libraries.byteBuddy )
-	testRuntime( libraries.woodstox )
 
 	//Databases
 	testRuntime( libraries.h2 )

--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -118,7 +118,7 @@ ext {
             mariadb:         'org.mariadb.jdbc:mariadb-java-client:2.2.3',
 
             oracle:          'com.oracle.jdbc:ojdbc8:12.2.0.1',
-            mssql:           'com.microsoft.sqlserver:mssql-jdbc:6.4.0.jre8',
+            mssql:           'com.microsoft.sqlserver:mssql-jdbc:7.2.1.jre8',
             db2:             'com.ibm.db2:db2jcc:10.5',
             hana:            'com.sap.cloud.db.jdbc:ngdbc:2.2.16', // for HANA 1 the minimum required client version is 1.120.20
 

--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -53,9 +53,6 @@ ext {
             jandex:         'org.jboss:jandex:2.0.5.Final',
             classmate:      'com.fasterxml:classmate:1.3.4',
 
-            // Woodstox
-            woodstox:           "org.codehaus.woodstox:woodstox-core-asl:4.3.0",
-
             // Dom4J
             dom4j:          'org.dom4j:dom4j:2.1.1@jar',
 

--- a/hibernate-orm-modules/hibernate-orm-modules.gradle
+++ b/hibernate-orm-modules/hibernate-orm-modules.gradle
@@ -60,7 +60,7 @@ repositories {
 	mavenCentral()
 	maven {
 		name 'jboss-public'
-		url 'http://repository.jboss.org/nexus/content/groups/public/'
+		url 'https://repository.jboss.org/nexus/content/groups/public/'
 	}
 }
 


### PR DESCRIPTION
Mirror of hibernate hibernate-orm#3036
https://hibernate.atlassian.net/browse/HHH-13428: Minor cleanup of build scripts

~Based on #3035 , which should be merged first.~ => Done

I'm really not sure about the MSSQL JDBC driver update, which seems out of place, but it was part of the original patch. Note however that the version before update was 7.x in ORM 5.4, and it's 6.x here.
Feel free to leave this particular commit out if you don't think it's a good idea.
