### PR TITLE
Mirror of hibernate hibernate-orm#3208

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -184,6 +184,11 @@ public class H2Dialect extends Dialect {
 	}
 
 	@Override
+	public String toBooleanValueString(boolean bool) {
+		return String.valueOf( bool );
+	}
+
+	@Override
 	public LimitHandler getLimitHandler() {
 		return limitHandler;
 	}


### PR DESCRIPTION
Mirror of hibernate hibernate-orm#3208
H2 supports (ANSI-standard) [boolean literals](https://h2database.com/html/grammar.html#boolean), i.e. `true` and `false`. For some reason, probably oversight, our `H2Dialect` doesn't use 'em.

Does anyone know of any reason we shouldn't make the attached change?
