### PR TITLE
Mirror of hibernate hibernate-orm#3184

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/ClassWriter.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/ClassWriter.java
@@ -53,7 +53,8 @@ public final class ClassWriter {
 			String body = generateBody( entity, context ).toString();
 
 			FileObject fo = context.getProcessingEnvironment().getFiler().createSourceFile(
-					getFullyQualifiedClassName( entity, metaModelPackage )
+					getFullyQualifiedClassName( entity, metaModelPackage ),
+					entity.getTypeElement()
 			);
 			OutputStream os = fo.openOutputStream();
 			PrintWriter pw = new PrintWriter( os );

--- a/tooling/metamodel-generator/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/tooling/metamodel-generator/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor,isolating


### PR DESCRIPTION
Mirror of hibernate hibernate-orm#3184
Upgrade JPA MetaModel Generator (jpamodelgen) to support Gradle Incremental Compile

According to https://docs.gradle.org/current/userguide/java_plugin.html#sec:incremental_annotation_processing there are basically two requirements:

- Register your annotation processor in gradle specific meta-inf file
- For an _Isolating_ processor exactly one originating element must be specified with the Filer API.
